### PR TITLE
Upgrade to android 12

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,11 +7,11 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.mazenrashed.universalbluetoothprinter"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:name="com.mazenrashed.example.ApplicationClass">
-        <activity android:name="com.mazenrashed.example.MainActivity">
+        <activity
+            android:name="com.mazenrashed.example.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -21,7 +23,7 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".WoosimActivity"/>
+        <activity android:name=".WoosimActivity" />
     </application>
 
 </manifest>

--- a/printooth/build.gradle
+++ b/printooth/build.gradle
@@ -4,13 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 29
-
-
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -52,10 +50,10 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.paperdb:paperdb:2.6'
+    implementation 'io.paperdb:paperdb:2.7.1'
     //Runtime permissions
     implementation 'com.afollestad.assent:core:3.0.0-RC4'
-    implementation 'com.android.support:design:29.0.0'
+    implementation 'com.android.support:design:31.0.0'
 }
 repositories {
     mavenCentral()

--- a/printooth/src/main/AndroidManifest.xml
+++ b/printooth/src/main/AndroidManifest.xml
@@ -3,11 +3,13 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application android:theme="@style/AppTheme">
         <activity
             android:name="com.mazenrashed.printooth.ui.ScanningActivity"
+            android:exported="true"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">
             <intent-filter>
                 <action android:name="com.mazenrashed.universalbluethootprinter.ui.ScanningActivity.LAUNCH" />


### PR DESCRIPTION
This PR upgrade android version to 31 and add `exported` where it is needed.

If this PR is not merged you can use this dependency in the mean time :  

```
implementation 'com.github.playmoweb:Printooth:e9fd4e2378'
```

--------

@mazenrashed Your project has many old PR, could you please take some time to merge them and keep this project up to date ? If you don't have time for it anymore, at least allow other maintainers to help you on that :) 