### PR TITLE
Update paperdb to 2.7.2

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -29,7 +29,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/printooth/build.gradle
+++ b/printooth/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'io.github.pilgr:paperdb:2.7.1'
+    implementation 'io.github.pilgr:paperdb:2.7.2'
     //Runtime permissions
     implementation 'com.afollestad.assent:core:3.0.0-RC4'
     implementation 'com.android.support:design:31.0.0'


### PR DESCRIPTION
**Context:** 
My project just implemented Gradle Version Catalog. The requirement to use the Gradle Version Catalog is to update the Gradle version to 7.4. After upgrading Gradle Version to 7.4, an error occurred when I tried to print using your library in release variant (minifyEnabled=true). The error is similar to this [link](https://stackoverflow.com/questions/49422553/paperdbexception).
Errors:
```
Fatal Exception: io.paperdb.PaperDbException: Couldn't read/deserialize file /data/user/0/com.xxx.xxx/files/io.paperdb/paired printer.pt for table paired printer
       at io.paperdb.DbStoragePlainFile.readTableFile(DbStoragePlainFile.java:60)
       at io.paperdb.DbStoragePlainFile.select(DbStoragePlainFile.java:41)
       at io.paperdb.Book.read(Book.java:2)
       at com.mazenrashed.printooth.data.PairedPrinter$Companion.getPairedPrinter(PairedPrinter.java:12)
       at com.mazenrashed.printooth.Printooth.getPairedPrinter(Printooth.java:12)
       at com.mazenrashed.printooth.ui.ScanningActivity$BluetoothDevicesAdapter.getView(ScanningActivity.java:12)
       at android.widget.AbsListView.obtainView(AbsListView.java:2366)
       at android.widget.ListView.makeAndAddView(ListView.java:2052)
       at android.widget.ListView.fillSpecific(ListView.java:1482)
       at android.widget.ListView.layoutChildren(ListView.java:1790)
       at android.widget.AbsListView.onLayout(AbsListView.java:2165)
       at android.view.View.layout(View.java:20858)
       at android.view.ViewGroup.layout(ViewGroup.java:6264)
       at androidx.swiperefreshlayout.widget.SwipeRefreshLayout.onLayout(SwipeRefreshLayout.java:58)
       at android.view.View.layout(View.java:20858)
       at android.view.ViewGroup.layout(ViewGroup.java:6264)
       at android.widget.RelativeLayout.onLayout(RelativeLayout.java:1083)
       at android.view.View.layout(View.java:20858)
       at android.view.ViewGroup.layout(ViewGroup.java:6264)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
       at android.view.View.layout(View.java:20858)
       at android.view.ViewGroup.layout(ViewGroup.java:6264)
       at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1812)
       at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1656)
       at android.widget.LinearLayout.onLayout(LinearLayout.java:1565)
       at android.view.View.layout(View.java:20858)
       at android.view.ViewGroup.layout(ViewGroup.java:6264)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
       at android.view.View.layout(View.java:20858)
       at android.view.ViewGroup.layout(ViewGroup.java:6264)
       at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1812)
       at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1656)
       at android.widget.LinearLayout.onLayout(LinearLayout.java:1565)
       at android.view.View.layout(View.java:20858)
       at android.view.ViewGroup.layout(ViewGroup.java:6264)
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
       at com.android.internal.policy.DecorView.onLayout(DecorView.java:754)
       at android.view.View.layout(View.java:20858)
       at android.view.ViewGroup.layout(ViewGroup.java:6264)
       at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:2922)
       at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2437)
       at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1533)
       at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7455)
       at android.view.Choreographer$CallbackRecord.run(Choreographer.java:953)
       at android.view.Choreographer.doCallbacks(Choreographer.java:765)
       at android.view.Choreographer.doFrame(Choreographer.java:697)
       at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:939)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:193)
       at android.app.ActivityThread.main(ActivityThread.java:6702)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)
```
**Solution**
After after doing trial and error, this problem is solved by upgrading paperdb version to 2.7.2. Ref: https://github.com/pilgr/Paper/issues/196

For temporary solution:
```
implementation ‘io.github.pilgr:paperdb:2.7.2’
implementation(“com.github.mazenrashed:Printooth:1.3.1”, {
	exclude group: ‘io.github.pilgr:paperdb’
      })
```